### PR TITLE
Update JsonEncode / JsonDecode constructor for Symfony >= 4.2

### DIFF
--- a/JsonSchema/usage.rst
+++ b/JsonSchema/usage.rst
@@ -27,8 +27,8 @@ You will have to do this::
 
     $normalizers = Vendor\Library\Generated\Normalizer\NormalizerFactory::create();
     $encoders = [new Symfony\Component\Serializer\Encoder\JsonEncoder(
-        new Symfony\Component\Serializer\Encoder\JsonEncode(JSON_UNESCAPED_SLASHES),
-        new Symfony\Component\Serializer\Encoder\JsonDecode(false))
+        new Symfony\Component\Serializer\Encoder\JsonEncode([Symfony\Component\Serializer\Encoder\JsonEncode::OPTIONS => \JSON_UNESCAPED_SLASHES]),
+        new Symfony\Component\Serializer\Encoder\JsonDecode([Symfony\Component\Serializer\Encoder\JsonDecode::ASSOCIATIVE => false]))
     ];
 
     $serializer = new Symfony\Component\Serializer\Serializer($normalizers, $encoders);


### PR DESCRIPTION
Symfony 4.2 deprecated the use of arguments, a default context array must be provided.

Also, I'm not a big fan of this part of the documentation now; FQN are too long.

Could we use imports?

```php
use Symfony\Component\Serializer\Encoder\JsonDecode;
use Symfony\Component\Serializer\Encoder\JsonEncode;
use Symfony\Component\Serializer\Encoder\JsonEncoder;
use Symfony\Component\Serializer\Serializer;

$normalizers = \Elasticsearch\Normalizer\NormalizerFactory::create();
$encoders = [
    new JsonEncoder(
        new JsonEncode([JsonEncode::OPTIONS => \JSON_UNESCAPED_SLASHES]),
        new JsonDecode([JsonDecode::ASSOCIATIVE => false])
    )
];

$serializer = new Serializer($normalizers, $encoders);
```