### PR TITLE
Fixed typo about usage with Symfony recipe

### DIFF
--- a/components/OpenAPI.rst
+++ b/components/OpenAPI.rst
@@ -69,7 +69,7 @@ you can name it as you like and use the ``--config-file`` option to specify its 
     php vendor/bin/jane-openapi generate --config-file=jane-openapi-configuration.php
 
 .. note::
-    If you are using Symfony recipe, this command is embbeded in the ``bin/open-api-generate`` binary file, you only
+    If you are using Symfony recipe, this command is embbeded in the ``bin/jane-open-api-generate`` binary file, you only
     have to run it to make it work 🎉
 
 .. note::


### PR DESCRIPTION
Hello,

Right now I'm starting to use Jane Open API generator, and I noticed a small typo in the documentation: 
the file from the recipe has a different, see https://github.com/symfony/recipes-contrib/blob/master/jane-php/open-api-common/6.0/bin/jane-open-api-generate