### PR TITLE
Dropping incorrect quote from composer require.

### DIFF
--- a/documentation/OpenAPI.rst
+++ b/documentation/OpenAPI.rst
@@ -35,7 +35,7 @@ requirement. Choose your library depending on OpenAPI version you need (you can 
     composer require jane-php/open-api-runtime
 
     # OpenAPI 3
-    composer require --dev jane-php/open-api-3"
+    composer require --dev jane-php/open-api-3
     composer require jane-php/open-api-runtime
 
 With Symfony ecosystem, we created a recipe to make it easier to use Jane. You just have to allow contrib recipes before


### PR DESCRIPTION
There's a quote here that looks like a mistake. It breaks copy-pasting the commands.